### PR TITLE
Fix out of range on std::vector

### DIFF
--- a/src/Base.cpp
+++ b/src/Base.cpp
@@ -143,8 +143,7 @@ namespace saltpack {
                             publickey.data(), secretkey.data()) != 0)
             throw SaltpackException("Errors while generating shared symmetric key.");
 
-        return BYTE_ARRAY(&sharedSymmetricKeyL[sharedSymmetricKeyL.size() - 32],
-                          &sharedSymmetricKeyL[sharedSymmetricKeyL.size()]);
+        return BYTE_ARRAY(sharedSymmetricKeyL.end() - 32, sharedSymmetricKeyL.end());
     }
 
     BYTE_ARRAY Base::generateRecipientIdentifier(BYTE_ARRAY sharedSymmetricKey, BYTE_ARRAY payloadSecretboxNonce) {
@@ -153,7 +152,7 @@ namespace saltpack {
         BYTE_ARRAY concatHash = BYTE_ARRAY(crypto_auth_hmacsha512_BYTES);
         if (crypto_auth_hmacsha512_init(&state, SIGNCRYPTION_BOX_KEY_IDENTIFIER.data(),
                                         SIGNCRYPTION_BOX_KEY_IDENTIFIER.size()) != 0)
-            throw SaltpackException("Errors while initialising HMAC.");
+            throw SaltpackException("Errors while initializing HMAC.");
         if (crypto_auth_hmacsha512_update(&state, sharedSymmetricKey.data(), sharedSymmetricKey.size()) != 0)
             throw SaltpackException("Errors while updating HMAC.");
         if (crypto_auth_hmacsha512_update(&state, payloadSecretboxNonce.data(), payloadSecretboxNonce.size()) !=
@@ -171,7 +170,7 @@ namespace saltpack {
         BYTE_ARRAY concatHash = BYTE_ARRAY(crypto_auth_hmacsha512_BYTES);
         if (crypto_auth_hmacsha512_init(&state, SIGNCRYPTION_DERIVED_SYMMETRIC_KEY.data(),
                                         SIGNCRYPTION_DERIVED_SYMMETRIC_KEY.size()) != 0)
-            throw SaltpackException("Errors while initialising HMAC.");
+            throw SaltpackException("Errors while initializing HMAC.");
         if (crypto_auth_hmacsha512_update(&state, publickey.data(), publickey.size()) != 0)
             throw SaltpackException("Errors while updating HMAC.");
         if (crypto_auth_hmacsha512_update(&state, secretkey.data(), secretkey.size()) !=

--- a/src/MessageReader.cpp
+++ b/src/MessageReader.cpp
@@ -45,7 +45,7 @@ namespace saltpack {
             // read buffer
             unpacker.reserve_buffer(BUFFER_SIZE);
             input.read(unpacker.buffer(), BUFFER_SIZE);
-            long count = input.gcount();
+            std::streamsize count = input.gcount();
             unpacker.buffer_consumed((size_t) count);
 
             // try to extract object
@@ -76,7 +76,7 @@ namespace saltpack {
             // read buffer
             unpacker.reserve_buffer(BUFFER_SIZE);
             input.read(unpacker.buffer(), BUFFER_SIZE);
-            long count = input.gcount();
+            std::streamsize count = input.gcount();
             unpacker.buffer_consumed((size_t) count);
 
             // try to extract object
@@ -107,7 +107,7 @@ namespace saltpack {
             // read buffer
             unpacker.reserve_buffer(BUFFER_SIZE);
             input.read(unpacker.buffer(), BUFFER_SIZE);
-            long count = input.gcount();
+            std::streamsize count = input.gcount();
             unpacker.buffer_consumed((size_t) count);
 
             // try to extract object
@@ -139,7 +139,7 @@ namespace saltpack {
         while (!messageStream.eof()) {
 
             messageStream.read(buf.data(), BUFFER_SIZE);
-            long count = messageStream.gcount();
+            std::streamsize count = messageStream.gcount();
 
             message.write(buf.data(), count);
         }
@@ -179,7 +179,7 @@ namespace saltpack {
             // read buffer
             unpacker.reserve_buffer(BUFFER_SIZE);
             input.read(unpacker.buffer(), BUFFER_SIZE);
-            long count = input.gcount();
+            std::streamsize count = input.gcount();
             unpacker.buffer_consumed((size_t) count);
 
             // try to extract object
@@ -446,7 +446,7 @@ namespace saltpack {
                 // read buffer
                 unpacker.reserve_buffer(BUFFER_SIZE);
                 input.read(unpacker.buffer(), BUFFER_SIZE);
-                long count = input.gcount();
+                std::streamsize count = input.gcount();
                 unpacker.buffer_consumed((size_t) count);
 
                 if (unpacker.next(oh)) {
@@ -601,8 +601,8 @@ namespace saltpack {
             throw SaltpackException("Errors while decrypting payload.");
 
         // extract signature and message from chunk
-        BYTE_ARRAY detachedSignature(&chunk[0], &chunk[64]);
-        BYTE_ARRAY message(&chunk[64], &chunk[chunk.size()]);
+        BYTE_ARRAY detachedSignature(chunk.begin(), chunk.begin() + 64);
+        BYTE_ARRAY message(chunk.begin() + 64, chunk.end());
 
         // compute the signature input
         BYTE_ARRAY signatureInput = generateSignatureInput(nonce, headerHash, message, final);


### PR DESCRIPTION
Hello again.
Why do you use constructions like **&byte_array[byte_array(size)]** in your code? It can assert or even throw exception depend of STD library realization. Plz fix it. You can use **byte_array.end()** in most of cases.